### PR TITLE
fix:  cannot import name '_RetAddress' from '_socket' (unknown location)

### DIFF
--- a/src/high_level/scripts/launch_serveur.py
+++ b/src/high_level/scripts/launch_serveur.py
@@ -3,7 +3,7 @@
 # ---------------------------------------------------------------------------------------------------
 import logging
 
-from high_level import Serveur
+from high_level import Server
 
 if __name__ == "__main__":
     logging.basicConfig(
@@ -23,5 +23,5 @@ if __name__ == "__main__":
     log_lidar = logging.getLogger("src.HL.actionneur_capteur.Lidar")
     log_lidar.setLevel(level=logging.INFO)
 
-    boot = Serveur()
+    boot = Server()
     boot.main()

--- a/src/high_level/scripts/min_lidar.py
+++ b/src/high_level/scripts/min_lidar.py
@@ -1,10 +1,11 @@
 # you must run export PYTHONPATH=/home/intech/CoVAPSy/src/high_level before running this script
 
-import time
-import numpy as np
-from src.actionneur_capteur.lidar import Lidar
 import signal
-import sys
+import time
+
+import numpy as np
+
+from src.actionneur_capteur.lidar import Lidar
 
 IP = "192.168.0.10"
 PORT = 10940

--- a/src/high_level/src/high_level/__init__.py
+++ b/src/high_level/src/high_level/__init__.py
@@ -1,4 +1,4 @@
-from .serveur import Serveur
 from .backend import BackendAPI
+from .server import Server
 
-__all__ = ["Serveur", "BackendAPI"]
+__all__ = ["Server", "BackendAPI"]

--- a/src/high_level/src/high_level/server.py
+++ b/src/high_level/src/high_level/server.py
@@ -1,13 +1,3 @@
-from actionneur_capteur.master_i2c import I2CArduino
-from actionneur_capteur.tof import ToF
-
-
-from actionneur_capteur.lidar import Lidar
-
-
-from actionneur_capteur.camera import Camera
-
-
 import logging
 import textwrap
 import time
@@ -19,19 +9,23 @@ from luma.core.render import canvas
 from luma.oled.device import ssd1306
 from PIL import Image, ImageDraw, ImageFont
 
+from actionneur_capteur.camera import Camera
+from actionneur_capteur.lidar import Lidar
+from actionneur_capteur.master_i2c import I2CArduino
+from actionneur_capteur.tof import ToF
 from high_level.autotech_constant import SITE_DIR_BACKEND, TEXT_HEIGHT
 from programs.car import AIProgram
-from programs.initialisation import Initialisation
+from programs.initialization import Initialization
 from programs.poweroff import Poweroff
 from programs.ps4_controller_program import PS4ControllerProgram
 from programs.remote_control import RemoteControl
-from programs.ssh_programme import SshProgramme
+from programs.ssh_program import SshProgram
 from programs.utils.ssh import check_ssh_connections
 
 from .backend import BackendAPI
 
 
-class Serveur:
+class Server:
     def __init__(self):
         self.log = logging.getLogger(__name__)
         # initialization of different modules
@@ -61,11 +55,11 @@ class Serveur:
         self.process = None
         self.temp = None
 
-        self.initialisation_module = Initialisation(self)
+        self.initialization_module = Initialization(self)
 
         self.programs = [
-            SshProgramme(),
-            self.initialisation_module,
+            SshProgram(),
+            self.initialization_module,
             AIProgram(self),
             PS4ControllerProgram(),
             RemoteControl(),
@@ -82,19 +76,19 @@ class Serveur:
 
     @property
     def camera(self) -> Camera:
-        return self.initialisation_module.camera
+        return self.initialization_module.camera
 
     @property
     def lidar(self) -> Lidar:
-        return self.initialisation_module.lidar
+        return self.initialization_module.lidar
 
     @property
     def tof(self) -> ToF:
-        return self.initialisation_module.tof
+        return self.initialization_module.tof
 
     @property
     def arduino_I2C(self) -> I2CArduino:
-        return self.initialisation_module.arduino_I2C
+        return self.initialization_module.arduino_I2C
 
     @property
     def target_speed(self) -> float:

--- a/src/high_level/src/programs/__init__.py
+++ b/src/high_level/src/programs/__init__.py
@@ -1,19 +1,19 @@
 from .camera_serv import StreamHandler, StreamOutput, StreamServer, frame_buffer
 from .car import AIProgram, Car
-from .initialisation import Initialisation
+from .initialization import Initialization
 from .poweroff import Poweroff
 from .program import Program  # in first because other programs depend on it
 from .remote_control import RemoteControl
-from .ssh_programme import SshProgramme
+from .ssh_program import SshProgram
 
 __all__ = [
     "Program",
     "Car",
     "AIProgram",
     "RemoteControl",
-    "Initialisation",
+    "Initialization",
     "Poweroff",
-    "SshProgramme",
+    "SshProgram",
     "StreamServer",
     "StreamHandler",
     "StreamOutput",

--- a/src/high_level/src/programs/car.py
+++ b/src/high_level/src/programs/car.py
@@ -4,11 +4,12 @@ import time
 from threading import Thread
 from typing import Optional
 
+import numpy as np
+import onnxruntime as ort
+
 from actionneur_capteur import Lidar
 from actionneur_capteur.camera import Camera
 from actionneur_capteur.tof import ToF
-import numpy as np
-import onnxruntime as ort
 
 # Import constants from HL.Autotech_constant to share them between files and ease of use
 from high_level.autotech_constant import (
@@ -22,7 +23,7 @@ from high_level.autotech_constant import (
 )
 
 from .program import Program
-from .utils.driver import Driver
+from .utils import Driver
 
 
 class Car:

--- a/src/high_level/src/programs/initialization.py
+++ b/src/high_level/src/programs/initialization.py
@@ -14,7 +14,7 @@ class ProgramState(Enum):
     STOPPED = 3
 
 
-class Initialisation(Program):
+class Initialization(Program):
     def __init__(self, server) -> None:
         super().__init__()
         self.log = logging.getLogger(__name__)

--- a/src/high_level/src/programs/ssh_program.py
+++ b/src/high_level/src/programs/ssh_program.py
@@ -5,7 +5,7 @@ from programs.program import Program
 from programs.utils.ssh import check_ssh_connections
 
 
-class SshProgramme(Program):
+class SshProgram(Program):
     """Give information about SSH connections and IP address and if the car is in standby mode (when this program is running)"""
 
     def __init__(self) -> None:

--- a/src/high_level/src/programs/ssh_programme.py
+++ b/src/high_level/src/programs/ssh_programme.py
@@ -1,6 +1,3 @@
-from _socket import _RetAddress
-
-
 import socket
 import time
 
@@ -42,7 +39,7 @@ class SshProgramme(Program):
             self._last_ip_check = now
 
     @staticmethod
-    def get_local_ip() -> _RetAddress | None:
+    def get_local_ip() -> str | None:
         try:
             s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
             s.settimeout(0.1)


### PR DESCRIPTION
on the pi I have this for sshProgramme: 
Traceback (most recent call last):
  File "/home/intech/CoVAPSy/src/high_level/scripts/launch_serveur.py", line 6, in <module>
    from high_level import Serveur
  File "/home/intech/CoVAPSy/src/high_level/src/high_level/__init__.py", line 1, in <module>
    from .serveur import Serveur
  File "/home/intech/CoVAPSy/src/high_level/src/high_level/serveur.py", line 23, in <module>
    from programs.car import AIProgram
  File "/home/intech/CoVAPSy/src/high_level/src/programs/__init__.py", line 7, in <module>
    from .ssh_programme import SshProgramme
  File "/home/intech/CoVAPSy/src/high_level/src/programs/ssh_programme.py", line 1, in <module>
    from _socket import _RetAddress
ImportError: cannot import name '_RetAddress' from '_socket' (unknown location)

So i delete the import and made the output of the fonction just str or None type (and basicely i use it like an str)